### PR TITLE
Bump gitpod-laravel-starter to 1.4 (official)

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -53,4 +53,4 @@ RUN sudo bash -c ". /tmp/update-composer.sh" && rm /tmp/update-composer.sh
 RUN sudo bash -c ". /tmp/scaffold-project.sh" && rm /tmp/scaffold-project.sh
 
 # Force the docker image to build by incrementing this value
-ENV INVALIDATE_CACHE=226
+ENV INVALIDATE_CACHE=227

--- a/.gp/CHANGELOG.md
+++ b/.gp/CHANGELOG.md
@@ -1,0 +1,279 @@
+# Changelog
+
+## [v1.4.0](https://github.com/apolopena/gitpod-laravel-starter/tree/v1.4.0) (2022-01-28)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel-starter/compare/v1.3.0...v1.4.0)
+
+**Implemented enhancements:**
+
+- starter.ini: Allow the choice of which PPA to use for an optional install of PHP [\#172](https://github.com/apolopena/gitpod-laravel-starter/issues/172)
+- Add GnuPG Support to sign git commits [\#170](https://github.com/apolopena/gitpod-laravel-starter/issues/170)
+- Add an option in starter.ini to generate a phpinfo.php to /public [\#168](https://github.com/apolopena/gitpod-laravel-starter/issues/168)
+- Auto activate intelephense if license key is available [\#165](https://github.com/apolopena/gitpod-laravel-starter/issues/165)
+- Add PHP version to Project powered by and Summary [\#158](https://github.com/apolopena/gitpod-laravel-starter/issues/158)
+- Consolidate docker layers in .gitpod.Dockerfile [\#157](https://github.com/apolopena/gitpod-laravel-starter/issues/157)
+- starter.ini: Make the PHP version configurable [\#156](https://github.com/apolopena/gitpod-laravel-starter/issues/156)
+
+**Fixed bugs:**
+
+- Unable to install github-changelog-generator gem on Ruby \< 3.0 [\#190](https://github.com/apolopena/gitpod-laravel-starter/issues/190)
+- React example presets may not work properly with Laravel version \< 8 [\#186](https://github.com/apolopena/gitpod-laravel-starter/issues/186)
+- Make react example presets use their own package.json [\#185](https://github.com/apolopena/gitpod-laravel-starter/issues/185)
+- React example presets have some bad css/sass [\#184](https://github.com/apolopena/gitpod-laravel-starter/issues/184)
+- Leading and trailing whitespace for values in starter.ini can break the system [\#174](https://github.com/apolopena/gitpod-laravel-starter/issues/174)
+- starter.ini: Make VS-Code IDE Preview \(tab\) setting a configurable option. [\#161](https://github.com/apolopena/gitpod-laravel-starter/issues/161)
+- xdebug cannot be installed because the base image has been updated to php8. [\#155](https://github.com/apolopena/gitpod-laravel-starter/issues/155)
+- workspace-init-logger.sh does an error when ran outside the project root [\#148](https://github.com/apolopena/gitpod-laravel-starter/issues/148)
+
+**Closed issues:**
+
+- Remove hotfix 140 [\#188](https://github.com/apolopena/gitpod-laravel-starter/issues/188)
+- Document user editable files and suggested use of init-project.sh for migration and seeding [\#183](https://github.com/apolopena/gitpod-laravel-starter/issues/183)
+- Question about Database Migration  [\#182](https://github.com/apolopena/gitpod-laravel-starter/issues/182)
+- Add info about install-project-packages.sh to README [\#181](https://github.com/apolopena/gitpod-laravel-starter/issues/181)
+- Clarify which values in starter.ini require a docker image rebuild. [\#180](https://github.com/apolopena/gitpod-laravel-starter/issues/180)
+- Update README with information about configuring the PPA for optional install of PHP [\#177](https://github.com/apolopena/gitpod-laravel-starter/issues/177)
+- Update README with information about configuring GPG keys and Intelliphense [\#176](https://github.com/apolopena/gitpod-laravel-starter/issues/176)
+- Update README with information about configuring the version of PHP [\#173](https://github.com/apolopena/gitpod-laravel-starter/issues/173)
+- DevX: Normalize line endings in git [\#164](https://github.com/apolopena/gitpod-laravel-starter/issues/164)
+- Docs: setting breakpoints, Threads panel is now the CALL STACK panel [\#160](https://github.com/apolopena/gitpod-laravel-starter/issues/160)
+- Typo in README [\#153](https://github.com/apolopena/gitpod-laravel-starter/issues/153)
+- Fix usage comment for add\_file\_to\_file\_after\(\) in utils.sh [\#152](https://github.com/apolopena/gitpod-laravel-starter/issues/152)
+- Fix mispelling in before-tasks.sh header comment [\#151](https://github.com/apolopena/gitpod-laravel-starter/issues/151)
+- img tags in readme for powered by needs correction [\#150](https://github.com/apolopena/gitpod-laravel-starter/issues/150)
+- Fix multitail value comment in starter.ini [\#149](https://github.com/apolopena/gitpod-laravel-starter/issues/149)
+- update-pma-pws-help: recommended command is wrong [\#147](https://github.com/apolopena/gitpod-laravel-starter/issues/147)
+- WIKI \[setup page\]: Reword The Developer section [\#146](https://github.com/apolopena/gitpod-laravel-starter/issues/146)
+- Comment header in start-server.sh is incorrect [\#145](https://github.com/apolopena/gitpod-laravel-starter/issues/145)
+
+**Merged pull requests:**
+
+- 🚀 RELEASE: Version 1.4.0 - Hotfix 190 [\#191](https://github.com/apolopena/gitpod-laravel-starter/pull/191) ([apolopena](https://github.com/apolopena))
+- 🚀 RELEASE: Version 1.4.0 [\#189](https://github.com/apolopena/gitpod-laravel-starter/pull/189) ([apolopena](https://github.com/apolopena))
+
+## [v1.3.0](https://github.com/apolopena/gitpod-laravel-starter/tree/v1.3.0) (2021-05-22)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel-starter/compare/v1.2.0...v1.3.0)
+
+**Implemented enhancements:**
+
+- Make EXAMPLE presets be legitimate starting points [\#142](https://github.com/apolopena/gitpod-laravel-starter/issues/142)
+- Add a Typescript EXAMPLE 3 and 4: Questions and Answers React Typescript Web Feature [\#139](https://github.com/apolopena/gitpod-laravel-starter/issues/139)
+- Add  -\<port number\>  and --help options to op command [\#138](https://github.com/apolopena/gitpod-laravel-starter/issues/138)
+
+**Fixed bugs:**
+
+- init-project.sh should not have a copyright in the header [\#141](https://github.com/apolopena/gitpod-laravel-starter/issues/141)
+
+**Closed issues:**
+
+- Update EXAMPLE 1 and 2  to match the refactored code in EXAMPLE 3 and 4 [\#143](https://github.com/apolopena/gitpod-laravel-starter/issues/143)
+- Compliation of saas \>= 1.33.0 outputs DEPRECATION WARNING: Using / for division [\#140](https://github.com/apolopena/gitpod-laravel-starter/issues/140)
+
+**Merged pull requests:**
+
+- 🚀 RELEASE: Version 1.3.0 [\#144](https://github.com/apolopena/gitpod-laravel-starter/pull/144) ([apolopena](https://github.com/apolopena))
+
+## [v1.2.0](https://github.com/apolopena/gitpod-laravel-starter/tree/v1.2.0) (2021-05-10)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel-starter/compare/v1.1.0...v1.2.0)
+
+**Implemented enhancements:**
+
+- Allow for easy persistent configuration of apache [\#135](https://github.com/apolopena/gitpod-laravel-starter/issues/135)
+- Add a directive to starter.ini: laravel: include\_readme [\#128](https://github.com/apolopena/gitpod-laravel-starter/issues/128)
+
+**Fixed bugs:**
+
+- apache: rewriting the missing trailing slash when in an iframe breaks the page [\#134](https://github.com/apolopena/gitpod-laravel-starter/issues/134)
+- nginx: rewriting the missing trailing slash when in an iframe breaks the page [\#131](https://github.com/apolopena/gitpod-laravel-starter/issues/131)
+- op: opening url paths that end in a file name gives a 404 [\#130](https://github.com/apolopena/gitpod-laravel-starter/issues/130)
+- Fix bad logic for initially moving project files such as README.md [\#127](https://github.com/apolopena/gitpod-laravel-starter/issues/127)
+
+**Closed issues:**
+
+- Bump Xdebug to v3.0.4 [\#129](https://github.com/apolopena/gitpod-laravel-starter/issues/129)
+
+**Merged pull requests:**
+
+- 🚀 RELEASE: Version 1.2.0 [\#136](https://github.com/apolopena/gitpod-laravel-starter/pull/136) ([apolopena](https://github.com/apolopena))
+
+## [v1.0.0](https://github.com/apolopena/gitpod-laravel-starter/tree/v1.0.0) (2021-04-26)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel-starter/compare/v0.0.4...v1.0.0)
+
+**Implemented enhancements:**
+
+- include Laravel and laravel/ui version in Init summary [\#110](https://github.com/apolopena/gitpod-laravel-starter/issues/110)
+- allow\_mixed\_web directive in starter.ini  [\#109](https://github.com/apolopena/gitpod-laravel-starter/issues/109)
+- Provide a Vue EXAMPLE [\#105](https://github.com/apolopena/gitpod-laravel-starter/issues/105)
+- Make the version of Laravel configurable in starter.ini [\#102](https://github.com/apolopena/gitpod-laravel-starter/issues/102)
+- Support Laravel 6, 7 and future major releases [\#101](https://github.com/apolopena/gitpod-laravel-starter/issues/101)
+- ♻️ REFACTOR: bash scripts to pass shellcheck [\#93](https://github.com/apolopena/gitpod-laravel-starter/issues/93)
+- Support Nginx and php-fpm [\#89](https://github.com/apolopena/gitpod-laravel-starter/issues/89)
+- Add shellcheck [\#88](https://github.com/apolopena/gitpod-laravel-starter/issues/88)
+- Implement LICENSE files for third party software [\#86](https://github.com/apolopena/gitpod-laravel-starter/issues/86)
+- \[DEMO\] React Example without phpMyAdmin and no extras [\#84](https://github.com/apolopena/gitpod-laravel-starter/issues/84)
+- Give this project a license [\#81](https://github.com/apolopena/gitpod-laravel-starter/issues/81)
+- \[DEMO\] React QnA, full featured and barebones [\#80](https://github.com/apolopena/gitpod-laravel-starter/issues/80)
+- DEMO/EXAMPLE mode [\#79](https://github.com/apolopena/gitpod-laravel-starter/issues/79)
+- Init summary: colorize errors and successes [\#75](https://github.com/apolopena/gitpod-laravel-starter/issues/75)
+- starter.ini add react-router and react-router-dom [\#36](https://github.com/apolopena/gitpod-laravel-starter/issues/36)
+
+**Fixed bugs:**
+
+- Calling debug\_on without an argument should use the default server [\#111](https://github.com/apolopena/gitpod-laravel-starter/issues/111)
+- Only the major version is respected for Laravel install [\#107](https://github.com/apolopena/gitpod-laravel-starter/issues/107)
+- Vue EXAMPLE does not work properly in an iframe \(preview browser\) [\#106](https://github.com/apolopena/gitpod-laravel-starter/issues/106)
+- lint-starter has no success message [\#100](https://github.com/apolopena/gitpod-laravel-starter/issues/100)
+- Xdebug does not work in vscode [\#99](https://github.com/apolopena/gitpod-laravel-starter/issues/99)
+- nginx redirects urls with no trailing slash to a 404 [\#96](https://github.com/apolopena/gitpod-laravel-starter/issues/96)
+- The spinner in terminal during initialization shows garbage text [\#95](https://github.com/apolopena/gitpod-laravel-starter/issues/95)
+- phpmyadmin wont display in an iframe [\#94](https://github.com/apolopena/gitpod-laravel-starter/issues/94)
+- debug mode does not work with nginx [\#92](https://github.com/apolopena/gitpod-laravel-starter/issues/92)
+-  bash directory in the root is opinionated [\#91](https://github.com/apolopena/gitpod-laravel-starter/issues/91)
+- nginx server requires trailing slash locations like phpmyadmin [\#90](https://github.com/apolopena/gitpod-laravel-starter/issues/90)
+- vscode IDE preview browser does not open [\#87](https://github.com/apolopena/gitpod-laravel-starter/issues/87)
+- LICENSE file is in the way [\#83](https://github.com/apolopena/gitpod-laravel-starter/issues/83)
+- Restarting a workspaces gives an error when opening the preview [\#19](https://github.com/apolopena/gitpod-laravel-starter/issues/19)
+
+**Closed issues:**
+
+- Create the wiki - home page and setup page [\#114](https://github.com/apolopena/gitpod-laravel-starter/issues/114)
+- Remove support to configure the version of Vue in starter.ini [\#113](https://github.com/apolopena/gitpod-laravel-starter/issues/113)
+- Docker image can build a different version of laravel that what is in VCS [\#112](https://github.com/apolopena/gitpod-laravel-starter/issues/112)
+- ~ is not supported when setting a Laravel version in starter.ini [\#108](https://github.com/apolopena/gitpod-laravel-starter/issues/108)
+- Change repository name to gitpod-laravel-starter [\#104](https://github.com/apolopena/gitpod-laravel-starter/issues/104)
+- Document laravel version options [\#103](https://github.com/apolopena/gitpod-laravel-starter/issues/103)
+- Refactor snippets and .bashrc functions [\#98](https://github.com/apolopena/gitpod-laravel-starter/issues/98)
+- Document nginx server [\#97](https://github.com/apolopena/gitpod-laravel-starter/issues/97)
+- Document EXAMPLE mode [\#85](https://github.com/apolopena/gitpod-laravel-starter/issues/85)
+- ♻️ REFACTOR: log wrappers for init-workspace.log [\#82](https://github.com/apolopena/gitpod-laravel-starter/issues/82)
+
+**Merged pull requests:**
+
+- 🔀 MERGE: Features, Fixes, Docs and Tasks for version 1.0.0 [\#115](https://github.com/apolopena/gitpod-laravel-starter/pull/115) ([apolopena](https://github.com/apolopena))
+
+## [v0.0.4](https://github.com/apolopena/gitpod-laravel8-starter/tree/v0.0.4) (2021-03-29)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel8-starter/compare/v0.0.3...v0.0.4)
+
+**Implemented enhancements:**
+
+- Update npm to version 7.7.5 if needed [\#77](https://github.com/apolopena/gitpod-laravel8-starter/issues/77)
+- Init summary: colorize errors and successes [\#75](https://github.com/apolopena/gitpod-laravel8-starter/issues/75)
+- Add alias for help on how to use the alias update\_pma\_pws [\#68](https://github.com/apolopena/gitpod-laravel8-starter/issues/68)
+- Add phpMyAdmin section to README.md [\#66](https://github.com/apolopena/gitpod-laravel8-starter/issues/66)
+- Add a log message to the summary about securing phpmyadmin passwords [\#65](https://github.com/apolopena/gitpod-laravel8-starter/issues/65)
+- Support .starter.env for sensitive data like phpmyadmin credentials [\#64](https://github.com/apolopena/gitpod-laravel8-starter/issues/64)
+- Environment variables for things like phpmyadmin [\#59](https://github.com/apolopena/gitpod-laravel8-starter/issues/59)
+- Readme: Revamp and add TOC [\#58](https://github.com/apolopena/gitpod-laravel8-starter/issues/58)
+- Expand Gitlog with additional emoji and git aliases [\#39](https://github.com/apolopena/gitpod-laravel8-starter/issues/39)
+
+**Fixed bugs:**
+
+- front end scaffolding installations throw a npm error [\#76](https://github.com/apolopena/gitpod-laravel8-starter/issues/76)
+- phpmyadmin install directive gets cached in the workspace image [\#74](https://github.com/apolopena/gitpod-laravel8-starter/issues/74)
+- React and Vue projects only run on php dev server, fail on apache [\#69](https://github.com/apolopena/gitpod-laravel8-starter/issues/69)
+- 'before' tasks should be logged to file but not to the console [\#67](https://github.com/apolopena/gitpod-laravel8-starter/issues/67)
+- log functions in utils.sh cannot handle a string that starts with -- [\#63](https://github.com/apolopena/gitpod-laravel8-starter/issues/63)
+- yarn install and laravel mix called more times than needed during gitpod initialization [\#61](https://github.com/apolopena/gitpod-laravel8-starter/issues/61)
+- phpmyadmin: The phpMyAdmin configuration storage is not completely configured [\#60](https://github.com/apolopena/gitpod-laravel8-starter/issues/60)
+- Gitpod Internal: Cannot start apache [\#46](https://github.com/apolopena/gitpod-laravel8-starter/issues/46)
+- phpmyadmin warning: The configuration file now needs a secret passphrase \(blowfish\_secret\) [\#45](https://github.com/apolopena/gitpod-laravel8-starter/issues/45)
+- Change test-app to laravel8-starter [\#41](https://github.com/apolopena/gitpod-laravel8-starter/issues/41)
+
+**Merged pull requests:**
+
+- MERGE: More Features and Fixes for version 0.0.4 [\#78](https://github.com/apolopena/gitpod-laravel8-starter/pull/78) ([apolopena](https://github.com/apolopena))
+- Restore default installations [\#73](https://github.com/apolopena/gitpod-laravel8-starter/pull/73) ([apolopena](https://github.com/apolopena))
+- ⚰️ REMOVE: no longer needed clear.term.sh [\#72](https://github.com/apolopena/gitpod-laravel8-starter/pull/72) ([apolopena](https://github.com/apolopena))
+- Added Gitpod Caveats to TOC in README [\#71](https://github.com/apolopena/gitpod-laravel8-starter/pull/71) ([apolopena](https://github.com/apolopena))
+- 🔀 MERGE: Features and Fixes for version 0.0.4 [\#70](https://github.com/apolopena/gitpod-laravel8-starter/pull/70) ([apolopena](https://github.com/apolopena))
+- 🐛 FIX: make tail the default apache log monitor [\#56](https://github.com/apolopena/gitpod-laravel8-starter/pull/56) ([apolopena](https://github.com/apolopena))
+- Fixes and Features [\#55](https://github.com/apolopena/gitpod-laravel8-starter/pull/55) ([apolopena](https://github.com/apolopena))
+
+## [v0.0.3](https://github.com/apolopena/gitpod-laravel8-starter/tree/v0.0.3) (2021-03-07)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel8-starter/compare/v0.0.2...v0.0.3)
+
+**Implemented enhancements:**
+
+- Make the apache log monitor binary configurable in starter.ini [\#54](https://github.com/apolopena/gitpod-laravel8-starter/issues/54)
+- Add bash scaffolding for project specific bash code during the init command [\#43](https://github.com/apolopena/gitpod-laravel8-starter/issues/43)
+- configuration options for out of the box .editorconfig [\#34](https://github.com/apolopena/gitpod-laravel8-starter/issues/34)
+- Command to show pretty results of initialization / workspace image build [\#32](https://github.com/apolopena/gitpod-laravel8-starter/issues/32)
+- File persistence system for files outside the repository [\#31](https://github.com/apolopena/gitpod-laravel8-starter/issues/31)
+
+**Fixed bugs:**
+
+- Multitail wont start when apache is launched when terminal window is too small [\#53](https://github.com/apolopena/gitpod-laravel8-starter/issues/53)
+- Apache fails to start, cannot find public folder [\#52](https://github.com/apolopena/gitpod-laravel8-starter/issues/52)
+- No install of node packages when project is initialized [\#50](https://github.com/apolopena/gitpod-laravel8-starter/issues/50)
+- Conditionally create mysql database: laravel [\#49](https://github.com/apolopena/gitpod-laravel8-starter/issues/49)
+- Fix and cleanup phpmyadmin [\#48](https://github.com/apolopena/gitpod-laravel8-starter/issues/48)
+- php install errors when a workspace image is built [\#47](https://github.com/apolopena/gitpod-laravel8-starter/issues/47)
+- Do not open preview until the entire init sequence has completed [\#44](https://github.com/apolopena/gitpod-laravel8-starter/issues/44)
+- .gitignore is merged even if it does not need to be. [\#42](https://github.com/apolopena/gitpod-laravel8-starter/issues/42)
+- Missing and overwritten scaffolding files when scaffolding is already in VCS [\#40](https://github.com/apolopena/gitpod-laravel8-starter/issues/40)
+- .gitignore Laravel Mix artifacts [\#38](https://github.com/apolopena/gitpod-laravel8-starter/issues/38)
+- php \(or laravel\) dev server is required for Laravel projects using React [\#37](https://github.com/apolopena/gitpod-laravel8-starter/issues/37)
+
+**Merged pull requests:**
+
+- Fixes and enhancements [\#51](https://github.com/apolopena/gitpod-laravel8-starter/pull/51) ([apolopena](https://github.com/apolopena))
+- Feature \#34 [\#35](https://github.com/apolopena/gitpod-laravel8-starter/pull/35) ([apolopena](https://github.com/apolopena))
+
+## [v0.0.2](https://github.com/apolopena/gitpod-laravel8-starter/tree/v0.0.2) (2021-02-08)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel8-starter/compare/v0.0.1a...v0.0.2)
+
+**Implemented enhancements:**
+
+- Command to show pretty results of initialization / workspace image build [\#32](https://github.com/apolopena/gitpod-laravel8-starter/issues/32)
+- File persistence system for files outside the repository [\#31](https://github.com/apolopena/gitpod-laravel8-starter/issues/31)
+
+- Add CHANGELOG [\#27](https://github.com/apolopena/gitpod-laravel8-starter/issues/27)
+- Colorized spinner and  initialization summary [\#25](https://github.com/apolopena/gitpod-laravel8-starter/issues/25)
+- Autogenerating CHANGELOG.md capability [\#23](https://github.com/apolopena/gitpod-laravel8-starter/issues/23)
+- Optional installs of react, vue and bootstrap [\#20](https://github.com/apolopena/gitpod-laravel8-starter/issues/20)
+- Remove query parameter from the url for debug-on and debug-off [\#17](https://github.com/apolopena/gitpod-laravel8-starter/issues/17)
+- debug-on and debug-off commands should support apache [\#15](https://github.com/apolopena/gitpod-laravel8-starter/issues/15)
+- Make the web server that is used by default configurable [\#14](https://github.com/apolopena/gitpod-laravel8-starter/issues/14)
+- \[gitpod\] Starting and stopping apache and php dev server [\#13](https://github.com/apolopena/gitpod-laravel8-starter/issues/13)
+- Starter Configuration - phpmyadmin [\#8](https://github.com/apolopena/gitpod-laravel8-starter/issues/8)
+- Implement emoji-log standards to the Gitpod environment [\#6](https://github.com/apolopena/gitpod-laravel8-starter/issues/6)
+
+**Fixed bugs:**
+
+- Anything written to ~/ does not persist. ~/.gitconfig, ~/.rake, etc.. [\#30](https://github.com/apolopena/gitpod-laravel8-starter/issues/30)
+- phpmyadmin install configuration only works the very first time [\#28](https://github.com/apolopena/gitpod-laravel8-starter/issues/28)
+- Gitpod initialization messages are out of order [\#24](https://github.com/apolopena/gitpod-laravel8-starter/issues/24)
+- No gitpod init log [\#21](https://github.com/apolopena/gitpod-laravel8-starter/issues/21)
+- Move alias and function creation to .gitpod.Dockerfile [\#16](https://github.com/apolopena/gitpod-laravel8-starter/issues/16)
+- 9660+ extra files in phpmyadmin install [\#10](https://github.com/apolopena/gitpod-laravel8-starter/issues/10)
+- No .gitignore in the root of the project. [\#9](https://github.com/apolopena/gitpod-laravel8-starter/issues/9)
+- Project scaffolding conflicts after first push [\#3](https://github.com/apolopena/gitpod-laravel8-starter/issues/3)
+- Make MySql graceful when using gitpod/workspace-mysql on the first run [\#1](https://github.com/apolopena/gitpod-laravel8-starter/issues/1)
+
+**Closed issues:**
+
+- Update documentation for version 0.0.2 release [\#5](https://github.com/apolopena/gitpod-laravel8-starter/issues/5)
+
+**Merged pull requests:**
+
+- Features \#31 and \#32, Fixes \#30 [\#33](https://github.com/apolopena/gitpod-laravel8-starter/pull/33) ([apolopena](https://github.com/apolopena))
+- Update Readme for 0.0.2 release [\#29](https://github.com/apolopena/gitpod-laravel8-starter/pull/29) ([apolopena](https://github.com/apolopena))
+- Features \#25, \#23 and Fixes  \#21 and \#24 [\#26](https://github.com/apolopena/gitpod-laravel8-starter/pull/26) ([apolopena](https://github.com/apolopena))
+- Feature \#20: optional installs of react, vue and bootstrap [\#22](https://github.com/apolopena/gitpod-laravel8-starter/pull/22) ([apolopena](https://github.com/apolopena))
+- Features and Fixes: \#13 to \#17 [\#18](https://github.com/apolopena/gitpod-laravel8-starter/pull/18) ([apolopena](https://github.com/apolopena))
+- Feature \#8 Starter Confiuration \(phpmyadmin\) [\#12](https://github.com/apolopena/gitpod-laravel8-starter/pull/12) ([apolopena](https://github.com/apolopena))
+- Fix \#3 and Feature \#6 [\#7](https://github.com/apolopena/gitpod-laravel8-starter/pull/7) ([apolopena](https://github.com/apolopena))
+
+## [v0.0.1a](https://github.com/apolopena/gitpod-laravel8-starter/tree/v0.0.1a) (2021-01-27)
+
+[Full Changelog](https://github.com/apolopena/gitpod-laravel8-starter/compare/c47fbdc6ba57643370bdf32e52ab9854370961cc...v0.0.1a)
+
+**Merged pull requests:**
+
+- Graceful MySql [\#2](https://github.com/apolopena/gitpod-laravel8-starter/pull/2) ([apolopena](https://github.com/apolopena))

--- a/.gp/LICENSE
+++ b/.gp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Apolo Pena https://github.com/apolopena/gitpod-laravel-starter/blob/main/LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.gp/README.md
+++ b/.gp/README.md
@@ -1,0 +1,472 @@
+# Welcome
+
+🚀
+`gitpod-laravel-starter` generates a starting point for you to [develop in the cloud](https://www.gitpod.io/) with [Laravel](https://laravel.com/) web application framework, [MySql](https://www.mysql.com/products/community/) and pretty much any other technology you would like to add.
+* Supports Laravel 6, 7, and 8
+* Develop in the cloud on the [Gitpod](https://www.gitpod.io/) platform
+* Preconfigured yet fully customizable [LAMP](https://en.wikipedia.org/wiki/LAMP_(software_bundle)) or [LEMP](https://lemp.io/) stack
+* Full debugging capabilities
+* Preset frontends for [React](https://reactjs.org/), [Vue](https://vuejs.org/), and [Bootstrap](https://getbootstrap.com/).
+* Auth scaffolding can be included with any preset frontend
+
+If you want to jump right in to [setting up a project](https://github.com/apolopena/gitpod-laravel-starter/wiki/Setup) then have a look at the wiki [setup page](https://github.com/apolopena/gitpod-laravel-starter/wiki/Setup).
+
+The [wiki](https://github.com/apolopena/gitpod-laravel-starter/wiki/Setup) is designed to provide you with essential details not found in this document such as how to easily add [hot reloading](https://github.com/apolopena/gitpod-laravel-starter/wiki/Hot-Reload) and [Typescript](https://github.com/apolopena/gitpod-laravel-starter/wiki/Typescript) to your projects. 
+
+`gitpod-laravel-starter` is designed for any type of developer from beginner to professional to hobbyist. Developing in the cloud has many benefits including giving developers the freedom to try entire complex technological stacks with a single click.
+
+## _Powered 100% by open source_:
+<a href="https://www.gitpod.io/"><img src="https://gitpod.io/static/media/gitpod.2cdd910d.svg" alt="Gitpod - Spin up fresh, automated dev environments
+for each task, in the cloud, in seconds" width="70" ></a>**Gitpod**
+ <a href="https://laravel.com/"><img src="https://upload.wikimedia.org/wikipedia/commons/9/9a/Laravel.svg" alt="Laravel - The PHP Framework for Web Artisans" width="65" ><img src="https://laravel.com/img/logotype.min.svg" width="100"></a>
+ <a href="https://www.php.net/"><img src="https://www.php.net/images/logos/new-php-logo.svg" alt="PHP - A popular general-purpose scripting language that is especially suited to web development" width="130" ></a>
+
+<a href="https://www.mysql.com/products/community/"><img src="https://www.logo.wine/a/logo/MySQL/MySQL-Logo.wine.svg" alt="MySQL Community Edition - Freely downloadable version of the world's most popular open source database" width="140" ></a>
+ <a href="https://httpd.apache.org/"><img src="https://upload.wikimedia.org/wikipedia/commons/1/10/Apache_HTTP_server_logo_%282019-present%29.svg" alt="The Apache Software Foundation, Apache License 2.0 <http://www.apache.org/licenses/LICENSE-2.0>, via Wikimedia Commons" width="165" ></a>
+ <a href="hhttps://www.nginx.com/resources/wiki/"><img src="https://upload.wikimedia.org/wikipedia/commons/c/c5/Nginx_logo.svg" alt="NGINX - A free, open-source, high-performance HTTP server and reverse proxy, as well as an IMAP/POP3 proxy server." width="150" ></a>
+
+<a href="https://www.gnu.org/software/bash/"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4b/Bash_Logo_Colored.svg" alt="Bootstrap - Build fast, responsive sites with Bootstrap" width="80" ></a>
+  <a href="https://reactjs.org/"><img src="https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg" alt="Bash  A Unix shell and command language written by Brian Fox for the GNU Project" width="115" ></a>
+<a href="https://vuejs.org/"><img src="https://upload.wikimedia.org/wikipedia/commons/9/95/Vue.js_Logo_2.svg" alt="Vue.js - The Progressive
+JavaScript Framework" width="72" ></a>
+  <a href="https://getbootstrap.com/"><img src="https://cdn.worldvectorlogo.com/logos/bootstrap-5-1.svg" alt="Bootstrap - Build fast, responsive sites with Bootstrap" width="82" ></a>
+
+
+<br />
+
+# Table of Contents
+
+1. [Welcome](#welcome)
+2. [Requirements](#requirements)
+3. [Setting Up a Repository](#setting-up-a-repository)
+   - 3.1 [Creating a new Gitpod Workspace from a GitHub repository](#creating-a-new-gitpod-workspace-from-a-github-repository)
+4. [Running the Client](#running-the-client)
+5. [Pushing Laravel scaffolding Files to Your Remote Repository](#pushing-laravel-scaffolding-files-to-your-remote-repository)
+   - 5.1 [Gitpod Account Permissions](#gitpod-account-permissions)
+   - 5.2 [GitHub Email Protection](#github-email-protection)
+6. [Starter Project Configuration](#starter-project-configuration)
+   - 6.1 [Preset Examples](#preset-examples)
+   - 6.2 [Development Servers](#development-servers)
+   - 6.3 [Changing the Default Server](#changing-the-default-server)
+   - 6.4 [Running More Than one Server at a Time](#running-more-than-one-server-at-a-time)
+   - 6.5 [Changing the PHP Version and PPA](#changing-the-php-version-and-ppa)
+   - 6.6 [Changing the Laravel Version](#changing-the-laravel-version)
+   - 6.7 [Breaking the Docker cache](#breaking-the-docker-cache)
+7. [Gitpod Environment Variables](#gitpod-environment-variables)
+   - 7.1 [Sign Git commits with a GPG key](#sign-git-commits-with-a-gpg-key)
+   - 7.2 [Activate an Intelliphense License Key](#activate-an-intelliphense-license-key)
+8. [Additional Features](#additional-features)
+   - 8.1 [Hot Reloading](#hot-reloading)
+   - 8.2 [Typescript](#typescript)
+9. [Debugging PHP](#debugging-php)
+   - 9.1 [The Default Development Server](#the-default-development-server)
+   - 9.2 [Specific Development Servers](#specific-development-servers)
+   - 9.3 [Setting Breakpoints](#setting-breakpoints)
+   - 9.4 [Debugging Blade Templates](#debugging-blade-templates)
+   - 9.5 [Tailing the Xdebug Log](#tailing-the-xdebug-log)
+10. [Debugging JavaScript](#debugging-javascript)
+11. [phpMyAdmin](#phpmyadmin)
+    - 11.1 [Installing phpMyAdmin](#installing-phpmyadmin)
+    - 11.2 [Security Concerns](#security-concerns)
+    - 11.3 [Securing phpMyAdmin](#securing-phpmyadmin)
+12. [Generating a CHANGELOG.md Using github-changelog-generator](#generating-a-changelogmd-using-github-changelog-generator)
+    - 12.1 [Setting up an Access Token for github-changelog-generator](#setting-up-an-access-token-for-github-changelog-generator)
+13. [Project Specific Bash Code and Package Installation](#project-specific-bash-code-and-package-installation)
+    - 13.1 [User Editable Files](#user-editable-files)
+    - 13.2 [Migration and Seeding](#migration-and-seeding)
+14. [Ruby Gems](#ruby-gems)
+15. [Git Aliases](#git-aliases)
+   - 15.1 [Emoji-log and Gitmoji](#emoji-log-and-gitmoji)
+16. [Deployment Outside of Gitpod](#deployment-outside-of-gitpod)
+17. [Gitpod Caveats](#gitpod-caveats)
+18. [Thanks](#thanks)
+
+<br />
+
+## Requirements
+
+- A [GitHub](https://github.com/) account. You may use a free account.
+
+- A [GitPod](https://www.gitpod.io/) account. You may use a free account. Just log in with your github credentials.
+
+<br />
+
+## Setting Up a Repository
+There are many ways that you can [use `gitpod-laravel-starter`](https://github.com/apolopena/gitpod-laravel-starter/wiki/Setup). __Full setup instructions can be found on the wiki [setup page](https://github.com/apolopena/gitpod-laravel-starter/wiki/Setup)__.
+
+### Creating a new Gitpod Workspace from a Github repository
+
+Gitpod makes this easy. One simple URL deploys the entire system.
+
+__A detailed breakdown of the initialization phase can be found on the wiki [initialization page](https://github.com/apolopena/gitpod-laravel-starter/wiki/Initialization)__
+
+   - Paste your GitHub repository URL to the end of the special Gitpod URL: **https://gitpod.io/#/**.
+   - If you don't need to push changes and you just want to try this repository with the default configuration you can click here [![Try it out on on Gitpod.io](https://gitpod.io/button/open-in-gitpod.svg)](http://gitpod.io/#/https://github.com/apolopena/gitpod-laravel-starter)
+   - Instructions for setting up a repository of your own can be found on the wiki [setup page](https://github.com/apolopena/gitpod-laravel-starter/wiki/Setup)
+
+Initializing the workspace will take between 2 to 5 minutes depending on how you have [configured](#starter-project-configuration) the [`starter.ini`](https://github.com/apolopena/gitpod-laravel-starter/blob/main/starter.ini) file. Subsequent starts or creation of a workspace from your repository will be much faster thanks to caching mechanisms.
+
+When the workspace is created for the first time an entire online development environment complete with an IDE is deployed along with any additional installations you have set in `starter.ini`. Laravel scaffolding files and debugging capabilities are created the first time you build the workspace so you should push any new files to your repository before you get started developing your project. You can push the files with a single command: `git new "Initial Commit"`
+
+<br />
+
+## Running the Client
+
+A preview browser should automatically open and display the Laravel start page once the system is ready. This page is served by the default web server which is set in `starter.ini`. The code for the Laravel start page page is in `/resources/views/welcome.blade.php`. To manually open the preview browser or to refresh it you can run the command `op`.
+
+<br />
+
+## Pushing Laravel scaffolding Files to Your Remote Repository
+
+If the result log summary in the console shows success, then you should push those newly created Laravel scaffolding files to your remote repository before you get started coding your project. 
+
+### Gitpod Account Permissions
+
+You may need to allow Gitpod additional permissions to push to your repository in case you come across an issue like [this one](https://community.gitpod.io/t/i-cant-push-my-changes-to-my-github-remote-repository/629).
+
+### GitHub Email Protection
+
+If your GitHub account uses the protected email feature and the email address you are using in your git configuration looks something like this:
+
+`3366792+myusername@users.noreply.github.com`
+
+you may encounter an error that looks something like this:
+
+`! [remote rejected] readme-dev -> readme-dev (push declined due to email privacy restrictions)`
+
+The easiest way to circumvent error is to uncheck the box labeled "**Block command line pushes that expose my email**" under **Settings**-->**Emails** in your GitHub account.
+
+Another workaround is to edit the `~/.gitconfig` file in your Gitpod workspace to use your protected email address since Gitpod defaults to using the unprotected email address for your GitHub account. Please note that if you do this you will have to make this change for **_every_** time  you create a new workspace.
+
+<br />
+
+## Starter Project Configuration
+
+A configuration file has been provided to allow you to control many aspects of the development environment and the Laravel project scaffolding.
+
+The file [`starter.ini`](https://github.com/apolopena/gitpod-laravel-starter/blob/hot-reload/starter.ini) in the root of the project allows you to configure optional installations and other various options. Have a look at the comments in `starter.ini` for details and acceptable values you can use. Simply change values in `starter.ini`, push those changes to your repository, create a new Gitpod workspace from that repository and your new configurations will be enabled. Some of the configurations you can make are:
+-  Server: `apache`, `nginx` or `php` (development server)
+-  Optional installations
+    - `phpMyAdmin`
+    - Frontend: `react`, `vue` or plain `bootstrap`
+    - Your servers log monitor: `tail` with colorized log or `multitail`
+    - `.editorconfig`: You can omit this file or use a less opinionated version of this file than what Laravel gives you by default
+    - [github-change-log-generator](https://github.com/github-changelog-generator/github-changelog-generator)
+
+*Please note that many of the configurations found in `starter.ini` should be made just once __prior__ to creating your workspace for the first time. Have a look at the comments in [`starter.ini`](https://github.com/apolopena/gitpod-laravel-starter/blob/main/starter.ini) for specifics.*
+
+### Preset Examples
+`gitpod-laravel-starter` preset examples are auto-configured examples of React and Vue projects that you can learn from or use as starting points for your own projects.
+
+You can initialize a preset example as a starting point by adding `EXAMPLE=<id>` to the Gitpod URL right after the `#` and followed by a `/`.
+
+To use a preset example as a starting point:
+1. [Setup a project repository](https://github.com/apolopena/gitpod-laravel-starter/wiki/Setup#create-a-new-project-repository-from-gitpod-laravel-starter)
+2. Initialize your workspace using the workspace URL for your corresponding EXAMPLE id but substitute https://github.com/apolopena/gitpod-laravel-starter with your project repository URL.
+3. Save the system generated project scaffolding files to your new repository and you can start your project from that point.
+    - Please that some directives in `starter.ini` such as `phpmyadmin` will not be supercded on subsequent initializations of your workspace. Edit your `starter.ini` as needed.
+
+| id | Description | Workspace URL |
+| :---:  | :--- | :--- |
+| 1 | React Example with phpMyAdmin - Questions and Answers | https://gitpod.io/#EXAMPLE=1/https://github.com/apolopena/gitpod-laravel-starter |
+| 2 | React Example without phpMyAdmin - Questions and Answers | https://gitpod.io/#EXAMPLE=2/https://github.com/apolopena/gitpod-laravel-starter |
+| 3 __*__ | React Typescript Example with phpMyAdmin - Questions and Answers | https://gitpod.io/#EXAMPLE=3/https://github.com/apolopena/gitpod-laravel-starter |
+| 4 __*__ | React Typescript Example without phpMyAdmin - Questions and Answers | https://gitpod.io/#EXAMPLE=4/https://github.com/apolopena/gitpod-laravel-starter |
+| 10 __**__ | Vue Example with phpMyAdmin - Material Dashboard | https://gitpod.io/#EXAMPLE=10/https://github.com/apolopena/gitpod-laravel-starter |
+| 11 __**__ | Vue Example without phpMyAdmin - Material Dashboard | https://gitpod.io/#EXAMPLE=11/https://github.com/apolopena/gitpod-laravel-starter |
+
+<br />__\*__ Comes with hot reload functionality
+<br />__\**__ Not designed to run in an iframe such as the preview browser in the IDE.
+
+### Development Servers
+
+`gitpod-laravel-starter` project comes pre-packaged with three development servers that serve on the following ports:
+
+- Apache: port 8001
+- Nginx (with `php-fpm`): port 8002
+- PHP Development Sever: port 8000
+
+By default the server set in `starter.ini` will be the server used. You can run any server at the same time or change your default server in `starter.ini` at any time. 
+
+Please note that Laravel uses the APP_URL and ASSET_URL variables set in `.env` to serve content. These values are set during workspace initialization and are based on the default server you are using. If you want serve the project using a different server _after_ a workspace has been created, then you will need to change APP_URL and ASSET_URL in `.env` to have the port number in it for the server you want to use.
+
+You may also run the PHP Development server manually via the command `php artisan serve` which will use port 8000.
+
+The default server will be started automatically when the workspace is started.
+
+You can toggle any server on and off from any terminal window by running the relevant command. These commands will also dynamically kill the log monitor process for that server:
+
+- Apache: `start_apache` or `stop_apache`
+- Nginx `start_nginx` or `stop_nginx`
+- PHP  built-in development server: `start_php_dev` or `stop_php_dev`
+
+### Changing the Default Server
+
+Change the value of  `default_server` in the `development` section of `starter.ini` to `apache`, `nginx`, or `php`. You will need to change the APP_URL and ASSET_URL in the `.env` file to use the port number for that server if you change the default development server *after* a workspace has been created.
+
+### Running More Than one Server at a Time
+
+You may start and stop multiple servers.
+
+If you have the Apache server running and you want to run the Nginx server at the same time just run this command:
+
+`start_nginx`
+
+The Nginx server will now be running in addition to the Apache server.
+
+Laravel requires a URL to be set in the `.env` file in the project root. This is done for you automatically when the workspace is initialized. The URL set in the `.env` file contains the server port. so if you want to properly serve Laravel pages from a server other than the default server you initialized the project with then will need to change the values for APP_URL and ASSET_URL accordingly.
+
+
+### __Changing the PHP version and PPA__
+In `starter.ini` there is a `[PHP]` section and directives to change the version of PHP and or the `ppa` used for downloading the PHP packages.
+
+<br />
+
+Note: _See [`starter.ini`](https://github.com/apolopena/gitpod-laravel-starter/blob/main/starter.ini) for more details._
+
+**The following values are supported in the `[PHP]` section of `starter.ini`:**
+- `version`
+  - `7.4`
+    - The default value
+    - Installs PHP 7.4. See [php.sh](https://github.com/apolopena/gitpod-laravel-starter/blob/main/.gp/bash/php.sh) for specifics.
+    - The current version of PHP that gitpod installs by default in their [`workspace-full`](https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile) image will be automatically purged.
+  - `gitpodlatest`
+    - This keeps the current version that gitpod installs by default in their [`workspace-full`](https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile) image.
+- `ppa`
+  - `OS`
+    - The default value
+    - Uses the standard Debian distribution ppa
+  - `ondrej`
+    - Uses `ppa:ondrej/php`. This [ppa](https://launchpad.net/~ondrej/+archive/ubuntu/php) is maintained by an individual but does support the of running multiple versions of PHP side by side.
+
+### __Changing the Laravel Version__
+In `starter.ini` there is a directive to change the version of Laravel. You should only change the version of Larvel *before* you create a new workspace. The laravel version directive is cached in the workspace image so changing it sometimes requires you to [break the Docker cache](#breaking-the-docker-cache)
+
+**Important**:
+- By default `gitpod-laravel-starter` uses the most recent version of Laravel. Currently the most recent version of Laravel is `8.*`
+- There are exactly three supported values for the Laravel version directive: `8.*`, `7.*`, and `6.*` 
+- Laravel will always use the most recent/stable minor and patch version for any major version.
+
+**Caveats**:
+ - __Upgrading or downgrading Laravel once Laravel scaffolding files have been saved to your repository is not advised and should be avoided.__
+ - Attempts to upgrade will will result in an automatic downgrade and could cause instability.
+ - Attempts to downgrade will be ignored and could cause instability.
+ - The Laravel version directive is cached in the workspace image so changing it requires you to break the Docker cache.
+
+ ### Breaking the Docker cache
+ You can break the Docker cache and force the workspace image to be rebuilt by incrementing the `INVALIDATE_CACHE` variable in `.gitpod.Dockerfile`. Push the changed `.gitpod.Dockerfile` to your repository, create a new gitpod workspace and the workspace image will be rebuilt. Any cached external files that Docker uses such as `starter.ini` will be updated.
+
+<br />
+
+
+## Gitpod Environment Variables
+The following features can be enabled through environment variables that have been set in your [Gitpod preferences](https://gitpod.io/variables).:
+<br />
+\* _Please note that storing sensitive data in environment variables is not ultimately secure but should be OK for most development situations._
+- ### Sign Git commits with a GPG key
+   - `GPG_KEY_ID` (required)
+     - The ID of the GPG key you want to use to sign your git commits
+   - `GPG_KEY` (required)
+     - Base64 encoded private GPG key that corresponds to your `GPG_KEY_ID`
+   - `GPG_MATCH_GIT_TO_EMAIL` (optional)
+     - Sets your git user.email in `~/.gitconfig` to the value provided
+   - `GPG_AUTO_ULTIMATE_TRUST` (optional)
+     - If the value is set to `yes` or `YES` then your `GPG_KEY` will be automatically ultimately trusted
+- ### Activate an Intelliphense License Key
+  - `INTELEPHENSE_LICENSEKEY`
+    - Creates `~/intelephense/licence.txt` and will contain the value provided
+    - This will activate [Intelliphense](https://intelephense.com/) for you each time the workspace is created or restarted
+
+<br />
+
+## Additional Features
+To keep the `gitpod-laravel-framework` as flexible as possible, some features have been left out of the `starter.ini` configuration file. These additional features can be easily added to your project using a one-time set up process.  Wiki pages are available for each additional feature below that you may want to add to your project. Some of these features are automatically enabled for certain [preset examples](#preset-examples).
+
+### Hot Reloading
+  - `gitpod-laravel-starter` makes it easy for you to add the ability to see your code changes in realtime without refreshing the browser. Take a look at the wiki [hot reload](https://github.com/apolopena/gitpod-laravel-starter/wiki/Hot-Reload) page for more details.
+
+### Typescript
+  - Adding [Typescript](https://www.typescriptlang.org/) to your project is simple. Have a look at the wiki [Typescript page](https://github.com/apolopena/gitpod-laravel-starter/wiki/Typescript) for an example.
+
+<br />
+
+## Debugging PHP
+
+Debugging must be enabled before breakpoints can be hit and will last for an hour before the debug session is disabled automatically.
+
+When debugging is enabled or disabled, the preview browser will reload the index page. When debugging is enabled, *each* subsequent request can be debugged for an hour or until debugging is disabled.
+
+This system uses port `9009` for the debugging. A launch configuration file is included in `.vscode/launch.json` and in `.theia/launch.json`.
+
+### The Default Development Server
+
+To enable a debugging session on the default development server run `debug_on` in a Gitpod terminal. 
+To disable a debugging session on the default development server run `debug_off` in a Gitpod terminal.
+
+### Specific Development Servers
+
+You can toggle a debugging session for a specific server:
+
+- Apache
+    - `debug_on apache` or `debug_off apache`
+- Nginx
+    - `debug_on nginx` or `debug_off nginx`
+- PHP (development server)
+    - `debug_on php` or `debug_off php`
+
+*The [hot reload](https://github.com/apolopena/gitpod-laravel-starter/wiki/Hot-Reload) webpack server on port 3005 is not supported by this debugging system. You may be able to [configure it on your own](https://stackoverflow.com/questions/28470601/how-to-do-remote-debugging-with-browser-sync) if you like.*
+
+### Setting Breakpoints
+
+Set a breakpoint in the Gitpod IDE by clicking in the gutter next to the line of code you want in any PHP file in the `public` folder (or deeper) 
+
+Then in the Gitpod IDE in the browser:
+1. Click the debug icon in the left side panel to open the Debug panel.
+2. Choose "Listen for XDebug" from the dropdown list.
+3. Click the green play button (you should see the status "RUNNING" in the CALL STACK panel)
+4. Refresh the preview browser either manually or by running the `op` command and your breakpoint will be hit in the IDE.
+
+All debugging is subject to a server timeout, just refresh preview browser or run the command `op` if this happens.
+
+### Debugging Blade Templates
+
+You may also debug blade templates by placing the following snippet above where you want to inspect the blade directive.
+
+```php
+<?php xdebug_break(); ?>
+```
+
+Save the file and refresh the preview browser when the debugger is in the IDE.
+
+This will open a temporary PHP file that has all the blade directives converted to `php` tags, you may set additional breakpoints in this code as well. Do not edit the code in these temporary files as it they be disposed at any time and are only derived for the current debugging session.
+
+If you are having trouble, launch the "Listen for Xdebug" launch configuration again and refresh the preview browser.
+
+<br />
+
+### Tailing the Xdebug Log
+You may want to see how Xdebug is working with your server when you are debugging PHP files. 
+   1. Open a new terminal in gitpod
+   2. Run the command: `tail -f /var/log/xdebug.log`
+
+<br />
+
+## Debugging JavaScript
+The is a rather diverse topic. To make a long story short it is possible but very situational.
+
+Have a look at the wiki [debugging JavaScript](https://github.com/apolopena/gitpod-laravel-starter/wiki/Debugging-JavaScript) page for details and exact steps you can take to debug various types of JavaScript.
+
+<br />
+
+## phpMyAdmin
+
+phpMyAdmin is a tool that handles MySQL administration over the web. This tool is very powerful and can be essential when developing MySQL powered systems especially in the cloud. For more information on what phpMyAdmin can do, check out the [official documentation](https://www.phpmyadmin.net/docs/), the [user guide](https://docs.phpmyadmin.net/en/latest/user.html) or just dabble around on the [demo server](https://www.phpmyadmin.net/try/).
+
+### Installing phpMyAdmin
+phpMyAdmin is installed automatically by default. A phpMyAdmin installation directive is available in `starter.ini` that allows you to omit the installation if you like.
+
+### Security Concerns
+
+phpMyAdmin also introduces some extra security concerns that you may want to address. If you have installed phpMyAdmin using the install directive in `starter.ini` then by default, two MySQL accounts are created using default passwords stored in version control:
+
+- **pmasu**: This is the 'super user' account that a developer can use to log into phpMyAdmin in order to administer any MySQL database.
+     - The default password for the user **pmasu** is: ***123456***
+- **pma**: This is the 'control user' that the phpMyAdmin uses internally to manage it's advanced storage features which are enabled by default. This user can only administer the `phpmyadmin` database and should not be used by anyone.
+  - The default password the 'control user' **pma** is: ***pmapass***
+
+<br />
+
+### Securing phpMyAdmin
+
+At a minimum the default passwords that phpMyAdmin uses to administer the MySQL databases should be changed right after a Gitpod workspace has been created for the first time. An `update-phpmyadmin-pws` command has been provided that automagically changes the default passwords for you.
+<br /><br />
+The following steps are required to successfully run the `update-phpmyadmin-pws` command:
+   1. Create a file in .gp named `.starter.env`. You can run this command from the project root: `cp .gp/.starter.env.example .gp/.starter.env`
+   2. Or Copy and paste all the keys containing `PHPMYADMIN` from `.gp/.starter.env.example` to your blank `.starter.env` file
+   3. In `.starter.env`, set your password values for the `PHPMYADMIN` keys and save the file
+   4. In a terminal run the alias: `update-phpmyadmin-pws`
+
+<br />
+
+## Generating a CHANGELOG.md Using github-changelog-generator
+
+Keeping track of your changes and releases can easily be automated.
+There is an option in `starter-ini` to install [`github-changelog-generator`](https://github.com/github-changelog-generator/github-changelog-generator). 
+This option is on by default and additional settings for this option can be found in `starter.ini`.
+You can generate a `CHANGELOG.md` by running the command:
+`rake changelog`
+Currently generating a changelog can only be done when the workspace is built for the first time. See [here](https://github.com/apolopena/gitpod-laravel-starter/issues/57) for more details. See [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) for documentation.
+
+### Setting up an Access Token for github-changelog-generator
+
+GitHub limits API calls unless using an [access token](https://github.com/settings/tokens/).
+`github-changelog-generator` uses the GitHub API to generate a `CHANGELOG.md` and will quickly max out of API calls if you try to generate the `CHANGELOG.md` more than a few times in a certain period of time.
+It is recommended that you setup an access token from your GitHub account and then set that access token in an environment variable via your Gitpod dashboard. This way any project you like can generate a `CHANGELOG.md` as many times as it likes without error.
+
+1. You can generate an access token [here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token). If the repository is public you do not need to grant any special privileges, just generate the token and copy it to your clipboard. Otherwise if the repository is private you need to grant it 'repo' privileges.
+2. Once you have the github access token copied to your clipboard, in your gitpod account go to settings in the Environment Variables section click the "Add Variable" button.
+3. For the 'name' field value type in `CHANGELOG_GITHUB_TOKEN`
+4. For the 'value' field paste in your github access token
+5. For the 'Organization/Repository' field you may leave it as it or type in GITHUBUSERNAME/* where GITHUBUSERNAME is the user name of your github account. This will allow you to use the github-changelog-generator as many times as you like for any of your repositories. 
+6. Restart or create a new workspace and you will now be able to use `github-changelog-generator` via the `rake changelog` command as many times as you like.
+
+Important Note: If you do not generate an access token for `github-changelog-generator`, and if you do not cancel the error that results when you exceed your Github API calls when using `github-changelog-generator` then you could potentially run out of space for your github workspaces and not be able to create any any new workspace or open any existing ones until you delete the offending workspace(s) or the system is cleared automatically.
+
+<br />
+
+## Project Specific Bash Code and Package Installation
+Most of the files in `gitpod-laravel-starter` are core files and should not be altered unless you open PR for `gitpod-laravel-starter` however some files are provided so that you can customize your project even further.
+<br />
+You are encouraged to put your project specific code in files mentioned below:
+### User Editable Files
+- `.gp/bash/init-project.sh`
+   - Contains some basic scaffolding and examples that you may use in your project.
+   - Bash code you would like to run when a workspace is created for the first time (initialization) should added here.
+- `.gp/bash/install-project-packages.sh`
+   - Packages that you would like installed (via `apt-get`) when the docker image layers are built can be added as a single space delimited string to this file.
+   - Any changes made to `.gp/bash/install-project-packages.sh` will require a rebuild of the Docker image layers before the workspace is created for the first time.
+   - To rebuild the Docker image layers increment the `INVALIDATE_CACHE` value in `.gitpod/Dockerfile` and push that change to the remote repository
+### Migration and Seeding
+It is recommended that you migrate and seed your project in this file: `.gp/bash/init-project.sh`.
+<br />
+[For example](https://github.com/apolopena/qna-demo-skeleton/blob/main/.gp/bash/init-project.sh), the [react preset](#preset-examples) makes use of `.gp/bash/init-project` for [migration and seeding](https://github.com/apolopena/qna-demo-skeleton/blob/main/.gp/bash/init-project.sh).
+<br />
+
+## Ruby Gems
+
+Currently until gitpod fixes the [issue](https://github.com/apolopena/gitpod-laravel-starter/issues/57) of ruby gems not persisting across workspace restarts, you can only use rake commands when the workspace is created for the first time.
+
+<br />
+
+## Git Aliases
+
+Git aliases that you would like to add to your project should be added to the [`alias`](https://github.com/apolopena/gitpod-laravel-starter/blob/main/.gp/snippets/git/aliases) file.  
+
+### Emoji-log and Gitmoji
+A compilation of git aliases from [Emoji-log](https://github.com/ahmadawais/Emoji-Log) and [Gitmoji](https://gitmoji.dev/) are included, use them as you like from the command line. There is also a separate set of emoji based git aliases that will commit the files with a message and push them to the repository *without* adding the files. Use these aliases for dealing with groups of files that need different commit messages but still need to use to Emoji-log and or Gitmoji standards. You can get a list of all the emoji based git aliases with the command: `git a`
+
+<br />
+
+## Deployment Outside of Gitpod
+
+For now this will be something you need to figure out, eventually some guidelines for how to do that may be added here.
+
+<br />
+
+## Gitpod Caveats
+Gitpod is an amazing and dynamic platform however sometimes during it's peak hours, latency can affect the workspace. Here are a few symptoms and their possible remedies. This section will be updated or removed as Gitpod evolves.
+  - **Symptom**: Workspace loads, IDE displays, however one or more terminals are blank.
+    - **Possible Fix**: Delete the workspace in your Gitpod dashboard and then [recreate the workspace](#creating-a-new-workspace-in-gitpod-from-your-new-github-project-repository).
+  - **Symptom**: Workspace loads, IDE displays, however no ports become available and or the spinner stays spinning in the terminal even after a couple of minutes.
+    - **Possible Fix**: Refresh the browser
+
+You can also try to remedy any rare Gitpod network hiccups by simply waiting 30 minutes and trying again.
+
+## Thank You
+
+🙏 to the communities of:
+
+- Gitpod
+- Laravel
+- VS Code
+- Xdebug

--- a/.gp/bash/examples/init-react-example.sh
+++ b/.gp/bash/examples/init-react-example.sh
@@ -15,11 +15,11 @@ all_zeros='^[0]+$'
 task_msg="Setting up React example: Questions and Answers"
 
 log "$task_msg"
-curl -LJO https://github.com/apolopena/qna-demo-skeleton/archive/refs/tags/1.1.0.tar.gz
+curl -LJO https://github.com/apolopena/qna-demo-skeleton/archive/refs/tags/1.1.1.tar.gz
 exit_codes+=($?)
-tar --overwrite -xvzf qna-demo-skeleton-1.1.0.tar.gz --strip-components=1
+tar --overwrite -xvzf qna-demo-skeleton-1.1.1.tar.gz --strip-components=1
 exit_codes+=($?)
-rm qna-demo-skeleton-1.1.0.tar.gz
+rm qna-demo-skeleton-1.1.1.tar.gz
 exit_codes+=($?)
 
 if [[ $(echo "${exit_codes[@]}" | tr -d '[:space:]') =~ $all_zeros ]]; then

--- a/.gp/bash/examples/init-react-typescript-example.sh
+++ b/.gp/bash/examples/init-react-typescript-example.sh
@@ -15,11 +15,11 @@ declare -a exit_codes=()
 task_msg="Downloading React Typescript example: Questions and Answers"
 
 log "$task_msg"
-curl -LJO https://github.com/apolopena/qna-typescript-demo-skeleton/archive/refs/tags/1.1.0.tar.gz
+curl -LJO https://github.com/apolopena/qna-typescript-demo-skeleton/archive/refs/tags/1.1.1.tar.gz
 exit_codes+=($?)
-tar --overwrite -xvzf qna-typescript-demo-skeleton-1.1.0.tar.gz --strip-components=1
+tar --overwrite -xvzf qna-typescript-demo-skeleton-1.1.1.tar.gz --strip-components=1
 exit_codes+=($?)
-rm qna-typescript-demo-skeleton-1.1.0.tar.gz
+rm qna-typescript-demo-skeleton-1.1.1.tar.gz
 exit_codes+=($?)
 
 if [[ $(echo "${exit_codes[@]}" | tr -d '[:space:]') =~ ^[0]+$ ]]; then
@@ -27,7 +27,5 @@ if [[ $(echo "${exit_codes[@]}" | tr -d '[:space:]') =~ ^[0]+$ ]]; then
 else
   log -e "ERROR: $task_msg"
 fi
-
-
 
 

--- a/.gp/bash/init-gitpod.sh
+++ b/.gp/bash/init-gitpod.sh
@@ -220,6 +220,9 @@ if [ ! -d "$GITPOD_REPO_ROOT/vendor" ]; then
   if [ "$installed_changelog_gen" == 1 ]; then
     msg="Installing github-changelog-generator"
     log_silent "$msg" && start_spinner "$msg" &&
+    # Hotfix https://github.com/github-changelog-generator/github-changelog-generator/issues/1003
+    # See https://github.com/apolopena/gitpod-laravel-starter/issues/190
+    gem install async -v '~> 1.29' &&
     gem install github_changelog_generator --no-document --silent
     err_code=$?
     if [[ $err_code != 0 ]]; then

--- a/.gp/bash/init-optional-scaffolding.sh
+++ b/.gp/bash/init-optional-scaffolding.sh
@@ -186,7 +186,6 @@ if [ $install_react == 1 ]; then
           log -e "ERROR: $sub_msg"
         fi
       fi
-      #hotfix140
       log "  --> Installing node modules and running Laravel Mix"
       yarn install && npm run dev
       npm run dev
@@ -220,7 +219,6 @@ if [[ $install_vue == 1 && $install_react != 1 ]]; then
     fi
     err_code=$?
     if [[ $err_code == 0 ]]; then
-      hotfix140
       log "SUCCESS: Vue$auth_msg has been installed"
       log "  --> Installing node modules and running Laravel Mix"
       yarn install && npm run dev

--- a/.gp/bash/init-project.sh
+++ b/.gp/bash/init-project.sh
@@ -4,32 +4,21 @@
 # Description:
 # Project specific initialization.
 
-all_zeros='^[0]+$'
-
 # Load logger
 . .gp/bash/workspace-init-logger.sh
-# Load spinner
-. .gp/bash/spinner.sh
 
-# remove unused scaffolding
-[[ -f resources/js/components/Example.js ]] && rm resources/js/components/Example.js
-[[ -f resources/views/welcome.blade.php ]] && rm resources/views/welcome.blade.php
+# BEGIN example code block - migrate database
+# . .gp/bash/spinner.sh # COMMENT: Load spinner
+# __migrate_msg="Migrating database"
+# log_silent "$__migrate_msg" && start_spinner "$__migrate_msg"
+# php artisan migrate
+# err_code=$?
+# if [ $err_code != 0 ]; then
+#  stop_spinner $err_code
+#  log -e "ERROR: Failed to migrate database"
+# else
+#  stop_spinner $err_code
+#  log "SUCCESS: migrated database"
+# fi
+# END example code block - migrate database
 
-# Migrate and Seed
-declare -a exit_codes=()
-msg="Migrating and seeding project database"
-log "$msg"
-php artisan migrate
-exit_codes+=($?)
-php artisan db:seed
-exit_codes+=($?)
-if [[ $(echo "${exit_codes[@]}" | tr -d '[:space:]') =~ $all_zeros ]]; then
-  log "SUCCESS: $msg"
-else
-  log -e "ERROR: $msg"
-fi
-
-# Hot reload
-msg="Setting up hot reload system"
-log_silent "$msg"
-if bash -ic "hot-reload setup"; then log_silent "SUCCESS: $msg"; else log_silent -e "ERROR: $msg"; fi

--- a/starter.ini
+++ b/starter.ini
@@ -52,7 +52,7 @@ ppa=OS
 # if generate_phpinfo = 1 then a simple pgpinfo.php page will be created in /public
 # if generate_phpinfo = 0 or any other value no action will be taken
 # Does not require a rebuild of the docker image layer when this value is changed.
-generate_phpinfo=1
+generate_phpinfo=0
 
 # Changing values in this section requires a rebuild of the docker image layers
 # Increment the value for INVALIDATE_CACHE in .gitpod.Dockerfile before the workspace is created.


### PR DESCRIPTION
Updating from the `gitpod-laravel-starter` development version 1.4 to the official 1.4 version: https://github.com/apolopena/gitpod-laravel-starter/releases/tag/v1.4.0